### PR TITLE
Available to include the attributes

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -14,7 +14,6 @@ function stringify (obj) {
 function parse (data) {
   return new Promise((resolve, reject) => {
     const options = {
-      ignoreAttrs: true,
       explicitArray: false,
       tagNameProcessors: [
         (name) => {

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -5,22 +5,9 @@ exports.stringify = stringify;
 exports.parse = parse;
 
 function stringify (obj) {
-  var xml = '';
-  for (var key in obj) {
-    var value = obj[key];
-    if (Array.isArray(value)) {
-      value.forEach(function (item) {
-        if (typeof item === 'object')
-          xml += '<' + key + '>' + stringify(item) + '</' + key + '>';
-        else
-          xml += '<' + key + '>' + item + '</' + key + '>';
-      });
-    } else if (typeof value === 'object') {
-      xml += '<' + key + '>' + stringify(value) + '</' + key + '>';
-    } else {
-      xml += '<' + key + '>' + value + '</' + key + '>';
-    }
-  }
+  let builder = new xml2js.Builder({headless: true});
+  let xml = builder.buildObject(obj);
+
   return xml;
 }
 

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -5,7 +5,7 @@ exports.stringify = stringify;
 exports.parse = parse;
 
 function stringify (obj) {
-  let builder = new xml2js.Builder({headless: true});
+  let builder = new xml2js.Builder({headless: true, renderOpts: {pretty: true, newline: '', indent: ''} });
   let xml = builder.buildObject(obj);
 
   return xml;

--- a/tests/xml.spec.js
+++ b/tests/xml.spec.js
@@ -4,7 +4,7 @@ describe('XML', () => {
   const xmlString = '<root><child>test</child></root>';
   const xmlObj = {
     root: {
-      child: ['test']
+      child: 'test'
     }
   };
 


### PR DESCRIPTION
The xml parser and generator are available to include the attributes.

```js
const body = {
  'root': {
    '$': { 'id': '9eed9de4-1c48-4b08-a41d-dac067fc1c0d', 'hoge': 'huga' },
    '_': 'inner_value'
  }
};
```

```xml
<root id="9eed9de4-1c48-4b08-a41d-dac067fc1c0d" hoge="huga">inner_value</root>
```